### PR TITLE
Initial attempt to fix static analisys issues

### DIFF
--- a/usual/time.c
+++ b/usual/time.c
@@ -37,10 +37,12 @@ char *format_time_ms(usec_t time, char *dst, unsigned dstlen)
 
 	sec = tv.tv_sec;
 	tm = localtime_r(&sec, &tmbuf);
-	snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d.%03d",
-		 tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-		 tm->tm_hour, tm->tm_min, tm->tm_sec,
-		 (int)(tv.tv_usec / 1000));
+	if (tm != NULL) {
+		snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d.%03d",
+			tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+			tm->tm_hour, tm->tm_min, tm->tm_sec,
+			(int)(tv.tv_usec / 1000));
+	}
 	return dst;
 }
 
@@ -56,9 +58,11 @@ char *format_time_s(usec_t time, char *dst, unsigned dstlen)
 		s = time / USEC;
 	}
 	tm = localtime_r(&s, &tbuf);
-	snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d",
-		 tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-		 tm->tm_hour, tm->tm_min, tm->tm_sec);
+	if (tm != NULL) {
+		snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d",
+			tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+			tm->tm_hour, tm->tm_min, tm->tm_sec);
+	}
 	return dst;
 }
 

--- a/usual/tls/tls_ocsp.c
+++ b/usual/tls/tls_ocsp.c
@@ -893,6 +893,9 @@ tls_ocsp_query_async(struct tls **ocsp_ctx_p, int *fd_p, struct tls_config *conf
 	}
 	return tls_ocsp_evloop(ctx, fd_p, config);
 failed:
+	free(ctx->ocsp_query->ocsp_url);
+	free(ctx->ocsp_query->request_data);
+	free(ctx->ocsp_query);
 	tls_free(ctx);
 	return -1;
 }
@@ -909,7 +912,8 @@ tls_ocsp_common_query(struct tls **ocsp_ctx_p, int *fd_p, struct tls_config *con
 
 	/* sync path */
 	while (1) {
-		ret = tls_ocsp_query_async(&ctx, &fd, config, target);
+		if (ctx)
+			ret = tls_ocsp_query_async(&ctx, &fd, config, target);
 		if (ret != TLS_WANT_POLLIN && ret != TLS_WANT_POLLOUT)
 			break;
 		ret = tls_ocsp_do_poll(ctx, ret, fd);

--- a/usual/tls/tls_util.c
+++ b/usual/tls/tls_util.c
@@ -139,7 +139,7 @@ tls_load_file(const char *name, size_t *len, char *password)
 
 	/* Or read the (possibly) encrypted key from file */
 	if ((fp = fdopen(fd, "r")) == NULL)
-		goto fail;
+		return (NULL);
 	fd = -1;
 
 	key = PEM_read_PrivateKey(fp, NULL, tls_password_cb, password);
@@ -167,7 +167,7 @@ tls_load_file(const char *name, size_t *len, char *password)
 
  fail:
 	free(buf);
-	if (fd != -1)
+	if (fd)
 		close(fd);
 	if (bio != NULL)
 		BIO_free_all(bio);


### PR DESCRIPTION
lib/usual/time.c:41: error: NULL_DEREFERENCE
  pointer `tm` last assigned on line 39 could be null and is dereferenced at line 41, column 4
  39.       tm = localtime_r(&sec, &tmbuf);
  40.       snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d.%03d",
  41. >          tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
  42.            tm->tm_hour, tm->tm_min, tm->tm_sec,
  43.            (int)(tv.tv_usec / 1000));

lib/usual/time.c:60: error: NULL_DEREFERENCE
  pointer `tm` last assigned on line 58 could be null and is dereferenced at line 60, column 4
  58.       tm = localtime_r(&s, &tbuf);
  59.       snprintf(dst, dstlen, "%04d-%02d-%02d %02d:%02d:%02d",
  60. >          tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
  61.            tm->tm_hour, tm->tm_min, tm->tm_sec);
  62.       return dst;

lib/usual/tls/tls_util.c:171: error: USE_AFTER_FREE
  pointer `fd` last assigned on line 124 was freed by call to `fdopen()` at line 141, column 12 and is dereferenced or freed at line 171, column 3
  169.       free(buf);
  170.       if (fd != -1)
  171. >         close(fd);
  172.       if (bio != NULL)
  173.           BIO_free_all(bio);

lib/usual/tls/tls_ocsp.c:912: error: NULL_DEREFERENCE
  pointer `&ctx` last assigned on line 903 could be null and is dereferenced by call to `tls_ocsp_query_async()` at line 912, column 9
  910.       /* sync path */
  911.       while (1) {
  912. >         ret = tls_ocsp_query_async(&ctx, &fd, config, target);
  913.           if (ret != TLS_WANT_POLLIN && ret != TLS_WANT_POLLOUT)
  914.               break;

lib/usual/tls/tls_ocsp.c:896: error: MEMORY_LEAK
   memory dynamically allocated to `ctx->ocsp_query` by call to `tls_ocsp_setup()` at line 886, column 9 is not reachable after line 896, column 2
  894.       return tls_ocsp_evloop(ctx, fd_p, config);
  895.   failed:
  896. >     tls_free(ctx);
  897.       return -1;
  898.   }

ps: These issues were found using Infer